### PR TITLE
Add package setup and adapt tutorial notebook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup
+
+setup(name='cleese',
+      version='0.1.0',
+      install_requires=['numpy', 'scipy'])


### PR DESCRIPTION
This change adds a minimal package setup with dependencies needed to install, e.g. in a virtualenv without Anaconda.

Also, adapted the tutorial notebook to run on Python 3.