### PR TITLE
Add tutorial byproducts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 
 .ipynb_checkpoints/tutorial-checkpoint.ipynb
+
+/CLEESE_output_data/
+/cleese.egg-info/
+/example.wav
+/tutorial/output/
+
+__pycache__/


### PR DESCRIPTION
Installing the project in a virtualenv and running through the tutorial produces a number of directories. This change ignores them, as well as Python 3 caches.