### PR TITLE
V2

### DIFF
--- a/cleese_stim/engines/phase_vocoder/bpf.py
+++ b/cleese_stim/engines/phase_vocoder/bpf.py
@@ -123,10 +123,17 @@ def createBPFfreqs(config):
     band_count = config["eq"]["band"]["count"]
 
     if config["eq"]["scale"] == "linear":
-        eqFreqVec = np.linspace(0., sr/float(2), band_count+1)
+        min_freq = float(config["eq"]["min_freq"])
+        max_freq = float(config["eq"]["max_freq"])
+        eqFreqVec = np.linspace(min_freq, max_freq, band_count+1)
+
     elif config["eq"]["scale"] == "mel":
-        minMel = 0
-        maxMel = freq2mel(sr/float(2))
+        minMel = freq2mel(config["eq"]["min_freq"])
+        if np.isnan(config["eq"]["max_freq"]):
+            maxMel = freq2mel(sr/float(2))
+        else:
+            maxMel = freq2mel(config["eq"]["max_freq"])
+
         melPerBin = (maxMel-minMel)/(band_count)
         eqFreqVec = melPerBin*np.ones(band_count)
         eqFreqVec = np.insert(eqFreqVec, 0, minMel)

--- a/cleese_stim/engines/phase_vocoder/phase_vocoder.py
+++ b/cleese_stim/engines/phase_vocoder/phase_vocoder.py
@@ -292,7 +292,8 @@ def processWithSTFT(waveIn, config, BPF):
         currBinVec = freqMat[i, :]/sr*2 * (n_fft//2+1)
         # piecewise-linear spectral envelope
         interpBPF[:, i] = np.interp(np.arange(0, n_fft//2+1),
-                                    currBinVec, amplMat[i, :])
+                                    currBinVec, amplMat[i, :],
+                                    left=0, right=0)
 
     # interpolate in time
     filterMat = np.zeros(stftMat.shape)

--- a/cleese_stim/engines/phase_vocoder/phase_vocoder.py
+++ b/cleese_stim/engines/phase_vocoder/phase_vocoder.py
@@ -304,7 +304,7 @@ def processWithSTFT(waveIn, config, BPF):
             filterMat[i, :] = np.interp(np.arange(0, numFrames),
                                         frameVec, interpBPF[i, :])
 
-    stftMat *= filterMat
+    stftMat *= np.power(10,filterMat/20)
 
     waveOut = istft(stftMat, win, n_fft, synHop)
 

--- a/tutorial/configs/chained_pitch_stretch.toml
+++ b/tutorial/configs/chained_pitch_stretch.toml
@@ -74,6 +74,8 @@ trTime = 0.05
 # mel, linear
 scale = 'mel'
 band.count = 10
+min_freq = 0
+max_freq = nan
 
 
 [gain]

--- a/tutorial/configs/cleese-phase-vocoder.toml
+++ b/tutorial/configs/cleese-phase-vocoder.toml
@@ -72,6 +72,8 @@ trTime = 0.05
 # mel, linear
 scale = 'mel'
 band.count = 10
+min_freq = 0
+max_freq = nan
 
 
 [gain]

--- a/tutorial/configs/random_pitch_profile.toml
+++ b/tutorial/configs/random_pitch_profile.toml
@@ -73,6 +73,8 @@ trTime = 0.02
 # # mel, linear
 # scale = 'mel'
 # band.count = 10
+# min_freq = 0
+# max_freq = nan
 #
 #
 # [gain]

--- a/tutorial/configs/random_speed_profile.toml
+++ b/tutorial/configs/random_speed_profile.toml
@@ -73,6 +73,8 @@ trTime = 0.05
 # # mel, linear
 # scale = 'mel'
 # band.count = 10
+# min_freq = 0
+# max_freq = nan
 #
 #
 # [gain]


### PR DESCRIPTION
Bugfix the "eq" transformation to apply the amplitude of the BPF's gain, not the gain directly, to the stft.
Add min_freq and max_freq parameters to the "eq" transformation, entering nan to max_freq use the Nyquist frequency as before.
Adjust .toml examples to contain the new min_freq max_freq parameters in "eq" transformation.
Adjust frequency interpolation in processWithSTFT to apply a nul gain  outside the min_freq max_freq band.

Best regards,
Paul Mblanc