### PR TITLE
Added a pitch extractor as part of cleese

### DIFF
--- a/cleese_stim/engines/engine.py
+++ b/cleese_stim/engines/engine.py
@@ -14,7 +14,7 @@ class Engine(ABC):
 
     @staticmethod
     @abstractmethod
-    def load_file(filename):
+    def load_file(file_name):
         raise NotImplementedError()
 
     @staticmethod

--- a/cleese_stim/engines/face_warp/face_warp.py
+++ b/cleese_stim/engines/face_warp/face_warp.py
@@ -14,9 +14,9 @@ import mediapipe as mp
 from os import path
 from scipy.spatial import Delaunay
 
-from .engine import Engine
-from ..cleese import log
-from ..third_party.mls.img_utils import mls_rigid_deformation
+from ..engine import Engine
+from ...cleese import log
+from ...third_party.mls.img_utils import mls_rigid_deformation
 
 
 DLIB_TO_MEDIAPIPE = [
@@ -194,7 +194,7 @@ def mediapipe_to_dlib(mediapipe_landmarks):
     return dlib
 
 
-class Mediapipe(Engine):
+class FaceWarp(Engine):
 
     @staticmethod
     def load_file(filename):
@@ -562,4 +562,4 @@ class Mediapipe(Engine):
 
     @staticmethod
     def name():
-        return "mediapipe"
+        return "facewarp"

--- a/cleese_stim/engines/phase_vocoder/phase_vocoder.py
+++ b/cleese_stim/engines/phase_vocoder/phase_vocoder.py
@@ -27,6 +27,8 @@ from .audio_engine import (
 from ..engine import Engine
 from ...cleese import log, load_config
 
+from .utils import wav_read, wav_write, extract_pitch 
+
 
 class PhaseVocoder(Engine):
 
@@ -125,7 +127,7 @@ class PhaseVocoder(Engine):
 
                 if config["main"]['chain'] and t > 0:
                     if file_output:
-                        waveIn, sr, sampleFormat = PhaseVocoder.wavRead(
+                        waveIn, sr, sampleFormat = PhaseVocoder.wav_read(
                                 currOutFile[i])
                     else:
                         waveIn = waveOut
@@ -202,54 +204,28 @@ class PhaseVocoder(Engine):
                     waveOut = waveOut/np.max(np.abs(waveOut))*0.999
                 
                 if file_output:            
-                    PhaseVocoder.wavWrite(waveOut, fileName=currOutFile[i],
+                    PhaseVocoder.wav_write(waveOut, fileName=currOutFile[i],
                                           sr=sr, sampleFormat=sampleFormat)
 
         if not file_output:
             return waveOut, BPF
 
     @staticmethod
-    def load_file(fileName):
-
-        sampleRate, wave = wav.read(fileName)
-
-        sampleFormat = wave.dtype
-
-        if sampleFormat in ('int16', 'int32'):
-            # convert to float
-            if sampleFormat == 'int16':
-                n_bits = 16
-            elif sampleFormat == 'int32':
-                n_bits = 32
-            wave = wave/(float(2**(n_bits - 1)))
-            wave = wave.astype('float32')
-
-        attributes = {
-            "sample_rate": sampleRate,
-            "sample_format": sampleFormat,
-        }
-        return wave, attributes
-
-    @staticmethod
     def name():
         return "phase_vocoder"
 
     @staticmethod
-    def wavRead(filename):
-        wave, attr = PhaseVocoder.load_file(filename)
-        return wave, attr["sample_rate"], attr["sample_format"]
+    def wav_read(filename):
+        return wav_read(filename)
 
     @staticmethod
-    def wavWrite(waveOut, fileName, sr, sampleFormat='int16'):
+    def wav_write(wave_out, file_name, sr, sample_format='int16'):
+        return wav_write(wave_out, file_name, sr, sample_format='int16')
 
-        if sampleFormat == 'int16':
-            waveOutFormat = waveOut * 2**15
-        elif sampleFormat == 'int32':
-            waveOutFormat = waveOut * 2**31
-        else:
-            waveOutFormat = waveOut
-        waveOutFormat = waveOutFormat.astype(sampleFormat)
-        wav.write(fileName, sr, waveOutFormat)
+    @staticmethod
+    def extract_pitch(x, sr, win=.02, bounds=[70,400], interpolate=True):
+        return extract_pitch(x, sr, win=.02, bounds=[70,400], interpolate=True)
+
 
     @staticmethod
     def create_BPF(trans, config_file, time_points, num_points, end_on_transition, eq_freqs=None):

--- a/cleese_stim/engines/phase_vocoder/phase_vocoder.py
+++ b/cleese_stim/engines/phase_vocoder/phase_vocoder.py
@@ -27,7 +27,7 @@ from .audio_engine import (
 from ..engine import Engine
 from ...cleese import log, load_config
 
-from .utils import wav_read, wav_write, extract_pitch 
+from .utils import load_file, wav_read, wav_write, extract_pitch 
 
 
 class PhaseVocoder(Engine):
@@ -204,8 +204,8 @@ class PhaseVocoder(Engine):
                     waveOut = waveOut/np.max(np.abs(waveOut))*0.999
                 
                 if file_output:            
-                    PhaseVocoder.wav_write(waveOut, fileName=currOutFile[i],
-                                          sr=sr, sampleFormat=sampleFormat)
+                    PhaseVocoder.wav_write(waveOut, file_name=currOutFile[i],
+                                          sr=sr, sample_format=sampleFormat)
 
         if not file_output:
             return waveOut, BPF
@@ -215,12 +215,16 @@ class PhaseVocoder(Engine):
         return "phase_vocoder"
 
     @staticmethod
-    def wav_read(filename):
-        return wav_read(filename)
+    def load_file(file_name): 
+        return load_file(file_name)
+
+    @staticmethod
+    def wav_read(file_name):
+        return wav_read(file_name)
 
     @staticmethod
     def wav_write(wave_out, file_name, sr, sample_format='int16'):
-        return wav_write(wave_out, file_name, sr, sample_format='int16')
+        return wav_write(wave_out, file_name, sr, sample_format)
 
     @staticmethod
     def extract_pitch(x, sr, win=.02, bounds=[70,400], interpolate=True):

--- a/cleese_stim/engines/phase_vocoder/utils.py
+++ b/cleese_stim/engines/phase_vocoder/utils.py
@@ -15,9 +15,9 @@ import math
 from ...third_party.yin import compute_yin
 
 
-def load_file(fileName):
+def load_file(file_name):
 
-    sampleRate, wave = wav.read(fileName)
+    sampleRate, wave = wav.read(file_name)
     sampleFormat = wave.dtype
     if sampleFormat in ('int16', 'int32'):
         # convert to float
@@ -34,21 +34,20 @@ def load_file(fileName):
     }
     return wave, attributes
 
-def wav_read(filename):
-    wave, attr = load_file(filename)
+def wav_read(file_name):
+    wave, attr = load_file(file_name)
     return wave, attr["sample_rate"], attr["sample_format"]
 
-def wav_write(waveOut, fileName, sr, sampleFormat='int16'):
+def wav_write(wave_out, file_name, sr, sample_format='int16'):
 
-    if sampleFormat == 'int16':
-        waveOutFormat = waveOut * 2**15
-    elif sampleFormat == 'int32':
-        waveOutFormat = waveOut * 2**31
+    if sample_format == 'int16':
+        wave_out_format = wave_out * 2**15
+    elif sample_format == 'int32':
+        wave_out_format = wave_out * 2**31
     else:
-        waveOutFormat = waveOut
-    waveOutFormat = waveOutFormat.astype(sampleFormat)
-    wav.write(fileName, sr, waveOutFormat)
-
+        wave_out_format = wave_out
+    wave_out_format = wave_out_format.astype(sample_format)
+    wav.write(file_name, sr, wave_out_format)
 
 def extract_pitch(x, sr, win=.02, bounds=[70,400], interpolate=True):
     
@@ -60,7 +59,10 @@ def extract_pitch(x, sr, win=.02, bounds=[70,400], interpolate=True):
         hop_size = int(sr / min_f0) + 1
     pitch, harmonic_rates, argmins, times = compute_yin(x, sr, 
         dataFileName=None, w_len=hop_size, w_step=hop_size, f0_min=min_f0, f0_max=max_f0, harmo_thresh=0.1)
+    
+    # third-party yin returns lists; convert to nparray
     pitch = np.array(pitch)
+    times = np.array(times)
 
     # clean up unvoiced areas
     # flag unvoiced as nan

--- a/cleese_stim/engines/phase_vocoder/utils.py
+++ b/cleese_stim/engines/phase_vocoder/utils.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''
+CLEESE toolbox
+v1.0: mar 2018, J.J. Burred <jjburred@jjburred.com> for IRCAM/CNRS
+v2.0: jan 2022, Lara Kermarec <lara.git@kermarec.bzh> for CNRS
+
+Audio utils functions for CLEESE's phase vocoder engine
+'''
+
+import scipy.io.wavfile as wav
+import numpy as np
+import math
+
+from ...third_party.yin import compute_yin
+
+
+def load_file(fileName):
+
+    sampleRate, wave = wav.read(fileName)
+    sampleFormat = wave.dtype
+    if sampleFormat in ('int16', 'int32'):
+        # convert to float
+        if sampleFormat == 'int16':
+            n_bits = 16
+        elif sampleFormat == 'int32':
+            n_bits = 32
+        wave = wave/(float(2**(n_bits - 1)))
+        wave = wave.astype('float32')
+
+    attributes = {
+        "sample_rate": sampleRate,
+        "sample_format": sampleFormat,
+    }
+    return wave, attributes
+
+def wav_read(filename):
+    wave, attr = load_file(filename)
+    return wave, attr["sample_rate"], attr["sample_format"]
+
+def wav_write(waveOut, fileName, sr, sampleFormat='int16'):
+
+    if sampleFormat == 'int16':
+        waveOutFormat = waveOut * 2**15
+    elif sampleFormat == 'int32':
+        waveOutFormat = waveOut * 2**31
+    else:
+        waveOutFormat = waveOut
+    waveOutFormat = waveOutFormat.astype(sampleFormat)
+    wav.write(fileName, sr, waveOutFormat)
+
+
+def extract_pitch(x, sr, win=.02, bounds=[70,400], interpolate=True):
+    
+    # extract raw pitch with yin
+    hop_size = int(np.floor(sr * win))
+    min_f0, max_f0 = bounds
+    # YIN assumes the analysis window is longer than the min_f0 period 
+    if hop_size < int(sr / min_f0): 
+        hop_size = int(sr / min_f0) + 1
+    pitch, harmonic_rates, argmins, times = compute_yin(x, sr, 
+        dataFileName=None, w_len=hop_size, w_step=hop_size, f0_min=min_f0, f0_max=max_f0, harmo_thresh=0.1)
+    pitch = np.array(pitch)
+
+    # clean up unvoiced areas
+    # flag unvoiced as nan
+    pitch[np.where(pitch == 0)[0]] = np.nan
+    # trim beginning and end nans
+    notnans = np.flatnonzero(~np.isnan(pitch))
+    if notnans.size:
+        pitch = pitch[notnans[0]: notnans[-1]+1]
+        times = times[notnans[0]: notnans[-1]+1]
+    else: 
+        pitch = times = []
+    
+    if(interpolate):  # interpolate nans
+        start_value = end_value = np.mean(pitch[np.nonzero(~np.isnan(pitch))])
+        pitch = interpolate_pitch(pitch, start_value = start_value, end_value = end_value)
+    
+    return pitch, times
+
+def interpolate_pitch(x, start_value, end_value): 
+    """Interpolate zeros in pitch series. Method = spline (order-3 polynomial), linear or none. 
+    Provide start_value, end_value to fix bounds. 
+    """
+    xp=np.where(np.invert(list(map(math.isnan, x))))[0]
+    fp=np.array(x)[np.where(np.invert(list(map(math.isnan, x))))]
+    return np.interp(x=range(len(x)), xp=xp,fp=fp)
+
+
+

--- a/cleese_stim/third_party/audio_processing.py
+++ b/cleese_stim/third_party/audio_processing.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+_author__ = "Patrice Guyot"
+__email__ = "patrice.guyot@irit.fr"
+__version__ = "1.1.0"
+
+"""
+***********************************************************************
+Name            : audio_processing.py
+Description     : The module implements a function to read audio file.
+Author          : Patrice Guyot.
+***********************************************************************
+"""
+
+
+
+from scipy.io.wavfile import read as wavread
+import logging
+from os import remove, sep
+import subprocess
+
+
+
+def audio_read(audioFilePath, formatsox=False):
+    """
+
+    Read an audio file (from scipy.io.wavfile)
+
+    A conversation of the aufio file can be processed using SOX (by default set at False).
+
+    :param audioFilePath: audio file name (with eventually the full path)
+    :type audioFilePath: str
+    :param formatsox: if set at True, us SOX to convert audio file in "wav file, 1 channel, 16 kHz, 16bits". Default: False
+    :type audioFilePath: str
+
+    :returns:
+        * sr: sampling rate of the signal
+        * sig: list of values of the signal
+    :rtype: tuple
+
+    """
+    logging.info('Reading of the audio file : ' + audioFilePath)
+    if formatsox:
+        tmpFile = "tmp.wav"
+        logging.info('\t- Conversion en wav 16k with SOX.')
+        cmd = "sox " + audioFilePath + " -c 1 -r 16k -b 16 -G " + tmpFile + " rate -m"
+        subprocess.check_call(cmd)
+        [sr, sig] = wavread(tmpFile)
+        remove(tmpFile)
+    else:
+        [sr, sig] = wavread(audioFilePath)
+
+    return sr, sig
+

--- a/cleese_stim/third_party/yin.py
+++ b/cleese_stim/third_party/yin.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+_author__ = "Patrice Guyot"
+__email__ = "patrice.guyot@irit.fr"
+__version__ = "1.1.0"
+
+"""
+***********************************************************************
+Name            : yin.py
+Description     : Fundamental frequency estimation. Based on the YIN alorgorithm [1]: De Cheveigné, A., & Kawahara, H. (2002). YIN, a fundamental frequency estimator for speech and music. The Journal of the Acoustical Society of America, 111(4), 1917-1930.
+Author          : Patrice Guyot. Previous works on the implementation of the YIN algorithm have been made thanks to Robin Larvor, Maxime Le Coz and Lionel Koenig.
+***********************************************************************
+
+"""
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.signal import fftconvolve
+from os import sep
+from .audio_processing import *
+import time
+
+
+
+def differenceFunction_original(x, N, tau_max):
+    """
+    Compute difference function of data x. This corresponds to equation (6) in [1]
+
+    Original algorithm.
+
+    :param x: audio data
+    :param N: length of data
+    :param tau_max: integration window size
+    :return: difference function
+    :rtype: list
+    """
+    df = [0] * tau_max
+    for tau in range(1, tau_max):
+         for j in range(0, N - tau_max):
+             tmp = long(x[j] - x[j + tau])
+             df[tau] += tmp * tmp
+    return df
+
+
+def differenceFunction_scipy(x, N, tau_max):
+    """
+    Compute difference function of data x. This corresponds to equation (6) in [1]
+
+    Faster implementation of the difference function.
+    The required calculation can be easily evaluated by Autocorrelation function or similarly by convolution.
+    Wiener–Khinchin theorem allows computing the autocorrelation with two Fast Fourier transforms (FFT), with time complexity O(n log n).
+    This function use an accellerated convolution function fftconvolve from Scipy package.
+
+    :param x: audio data
+    :param N: length of data
+    :param tau_max: integration window size
+    :return: difference function
+    :rtype: list
+    """
+    x = np.array(x, np.float64)
+    w = x.size
+    x_cumsum = np.concatenate((np.array([0]), (x * x).cumsum()))
+    conv = fftconvolve(x, x[::-1])
+    tmp = x_cumsum[w:0:-1] + x_cumsum[w] - x_cumsum[:w] - 2 * conv[w - 1:]
+    return tmp[:tau_max + 1]
+
+
+
+
+def differenceFunction(x, N, tau_max):
+    """
+    Compute difference function of data x. This corresponds to equation (6) in [1]
+
+    Fastest implementation. Use the same approach than differenceFunction_scipy.
+    This solution is implemented directly with Numpy fft.
+
+
+    :param x: audio data
+    :param N: length of data
+    :param tau_max: integration window size
+    :return: difference function
+    :rtype: list
+    """
+
+    x = np.array(x, np.float64)
+    w = x.size
+    tau_max = min(tau_max, w)
+    x_cumsum = np.concatenate((np.array([0.]), (x * x).cumsum()))
+    size = w + tau_max
+    p2 = (size // 32).bit_length()
+    nice_numbers = (16, 18, 20, 24, 25, 27, 30, 32)
+    size_pad = min(x * 2 ** p2 for x in nice_numbers if x * 2 ** p2 >= size)
+    fc = np.fft.rfft(x, size_pad)
+    conv = np.fft.irfft(fc * fc.conjugate())[:tau_max]
+    return x_cumsum[w:w - tau_max:-1] + x_cumsum[w] - x_cumsum[:tau_max] - 2 * conv
+
+
+
+def cumulativeMeanNormalizedDifferenceFunction(df, N):
+    """
+    Compute cumulative mean normalized difference function (CMND).
+
+    This corresponds to equation (8) in [1]
+
+    :param df: Difference function
+    :param N: length of data
+    :return: cumulative mean normalized difference function
+    :rtype: list
+    """
+
+    cmndf = df[1:] * range(1, N) / np.cumsum(df[1:]).astype(float) #scipy method
+    return np.insert(cmndf, 0, 1)
+
+
+
+def getPitch(cmdf, tau_min, tau_max, harmo_th=0.1):
+    """
+    Return fundamental period of a frame based on CMND function.
+
+    :param cmdf: Cumulative Mean Normalized Difference function
+    :param tau_min: minimum period for speech
+    :param tau_max: maximum period for speech
+    :param harmo_th: harmonicity threshold to determine if it is necessary to compute pitch frequency
+    :return: fundamental period if there is values under threshold, 0 otherwise
+    :rtype: float
+    """
+    tau = tau_min
+    while tau < tau_max:
+        if cmdf[tau] < harmo_th:
+            while tau + 1 < tau_max and cmdf[tau + 1] < cmdf[tau]:
+                tau += 1
+            return tau
+        tau += 1
+
+    return 0    # if unvoiced
+
+
+
+def compute_yin(sig, sr, dataFileName=None, w_len=512, w_step=256, f0_min=100, f0_max=500, harmo_thresh=0.1):
+    """
+
+    Compute the Yin Algorithm. Return fundamental frequency and harmonic rate.
+
+    :param sig: Audio signal (list of float)
+    :param sr: sampling rate (int)
+    :param w_len: size of the analysis window (samples)
+    :param w_step: size of the lag between two consecutives windows (samples)
+    :param f0_min: Minimum fundamental frequency that can be detected (hertz)
+    :param f0_max: Maximum fundamental frequency that can be detected (hertz)
+    :param harmo_tresh: Threshold of detection. The yalgorithmù return the first minimum of the CMND fubction below this treshold.
+
+    :returns:
+
+        * pitches: list of fundamental frequencies,
+        * harmonic_rates: list of harmonic rate values for each fundamental frequency value (= confidence value)
+        * argmins: minimums of the Cumulative Mean Normalized DifferenceFunction
+        * times: list of time of each estimation
+    :rtype: tuple
+    """
+
+    # print('Yin: compute yin algorithm')
+    tau_min = int(sr / f0_max)
+    tau_max = int(sr / f0_min)
+    
+    timeScale = range(0, len(sig) - w_len, w_step)  # time values for each analysis window
+    times = [t/float(sr) for t in timeScale]
+    frames = [sig[t:t + w_len] for t in timeScale]
+
+    pitches = [0.0] * len(timeScale)
+    harmonic_rates = [0.0] * len(timeScale)
+    argmins = [0.0] * len(timeScale)
+
+    for i, frame in enumerate(frames):
+
+        #Compute YIN
+        df = differenceFunction(frame, w_len, tau_max)
+        cmdf = cumulativeMeanNormalizedDifferenceFunction(df, tau_max)
+        p = getPitch(cmdf, tau_min, tau_max, harmo_thresh)
+        
+        #Get results
+        if np.argmin(cmdf)>tau_min:
+            argmins[i] = float(sr / np.argmin(cmdf))
+        if p != 0: # A pitch was found
+            pitches[i] = float(sr / p)
+            harmonic_rates[i] = cmdf[p]
+        else: # No pitch, but we compute a value of the harmonic rate
+            harmonic_rates[i] = min(cmdf)
+
+
+    if dataFileName is not None:
+        np.savez(dataFileName, times=times, sr=sr, w_len=w_len, w_step=w_step, f0_min=f0_min, f0_max=f0_max, harmo_thresh=harmo_thresh, pitches=pitches, harmonic_rates=harmonic_rates, argmins=argmins)
+        print('\t- Data file written in: ' + dataFileName)
+
+    return pitches, harmonic_rates, argmins, times
+
+
+def main(audioFileName="whereIam.wav", w_len=1024, w_step=256, f0_min=70, f0_max=200, harmo_thresh=0.85, audioDir="./", dataFileName=None, verbose=4):
+    """
+    Run the computation of the Yin algorithm on a example file.
+
+    Write the results (pitches, harmonic rates, parameters ) in a numpy file.
+
+    :param audioFileName: name of the audio file
+    :type audioFileName: str
+    :param w_len: length of the window
+    :type wLen: int
+    :param wStep: length of the "hop" size
+    :type wStep: int
+    :param f0_min: minimum f0 in Hertz
+    :type f0_min: float
+    :param f0_max: maximum f0 in Hertz
+    :type f0_max: float
+    :param harmo_thresh: harmonic threshold
+    :type harmo_thresh: float
+    :param audioDir: path of the directory containing the audio file
+    :type audioDir: str
+    :param dataFileName: file name to output results
+    :type dataFileName: str
+    :param verbose: Outputs on the console : 0-> nothing, 1-> warning, 2 -> info, 3-> debug(all info), 4 -> plot + all info
+    :type verbose: int
+    """
+
+    if audioDir is not None:
+        audioFilePath = audioDir + sep + audioFileName
+    else:
+        audioFilePath = audioFileName
+
+    sr, sig = audio_read(audioFilePath, formatsox=False)
+
+    start = time.time()
+    pitches, harmonic_rates, argmins, times = compute_yin(sig, sr, dataFileName, w_len, w_step, f0_min, f0_max, harmo_thresh)
+    end = time.time()
+    print("Yin computed in: ", end - start)
+
+    duration = len(sig)/float(sr)
+
+    if verbose >3:
+        ax1 = plt.subplot(4, 1, 1)
+        ax1.plot([float(x) * duration / len(sig) for x in range(0, len(sig))], sig)
+        ax1.set_title('Audio data')
+        ax1.set_ylabel('Amplitude')
+        ax2 = plt.subplot(4, 1, 2)
+        ax2.plot([float(x) * duration / len(pitches) for x in range(0, len(pitches))], pitches)
+        ax2.set_title('F0')
+        ax2.set_ylabel('Frequency (Hz)')
+        ax3 = plt.subplot(4, 1, 3, sharex=ax2)
+        ax3.plot([float(x) * duration / len(harmonic_rates) for x in range(0, len(harmonic_rates))], harmonic_rates)
+        ax3.plot([float(x) * duration / len(harmonic_rates) for x in range(0, len(harmonic_rates))], [harmo_thresh] * len(harmonic_rates), 'r')
+        ax3.set_title('Harmonic rate')
+        ax3.set_ylabel('Rate')
+        ax4 = plt.subplot(4, 1, 4, sharex=ax2)
+        ax4.plot([float(x) * duration / len(argmins) for x in range(0, len(argmins))], argmins)
+        ax4.set_title('Index of minimums of CMND')
+        ax4.set_ylabel('Frequency (Hz)')
+        ax4.set_xlabel('Time (seconds)')
+        plt.show()
+
+
+
+if __name__ == '__main__':
+    main()
+
+


### PR DESCRIPTION
##  What?

This adds a pitch extractor (YIN) to the cleese.PhaseVocoder engine; can be called statically with `PhaseVocoder.extract_pitch(x,sr)`

## Why?

Previous versions of CLEESE did not include a pitch extractor. While computing pitch is not necessary to manipulate pitch in PhaseVocoder, it is useful to e.g. visualize results and to compute custom BPF for flattening files. 
In the audio tutorial, we require that people install `pysptk` to access a third party pitch extractor (SWIPE), but installing it is cumbersome. Also, it turns out that flattening file in pitch is almost systematic use in CLEESE, so streamlining this is useful. 

## How?

* added a `utils.py` module in `engines/phase_vocoder/.`; moved PhaseVocoder functions `load_file`, `wav_read`, `wav_write` and created `extract_pitch`. All 4 functions in utils have accessors as static methods in the `PhaseVocoder` class (i.e. one can call `PhaseVocoder.extract_pitch`) 
* `extract_pitch` calls third_party code : a fast implementation of YIN (De Cheveigné & Kawahara) by Patrice Guyot; two files `yin.py` and `audio_processing` are copied to the `third_party` folder
* minor API changes: renamed wavRead and wavWrite functions as snake_case; rename MediaPipe as FaceWarp, moved to engine/face_warp

## Testing?

* tested changes using the audio_tutorial notebook; changed a few things in the notebook (calls to extract_pitch -> `PhaseVocoder.extract_pitch`; times now in seconds instead of millisec)



