### PR TITLE
Bpf file format

### DIFF
--- a/cleese_stim/engines/face_warp/face_warp.py
+++ b/cleese_stim/engines/face_warp/face_warp.py
@@ -383,9 +383,9 @@ class FaceWarp(Engine):
 
         # default configuration values
         try:
-            DFMXY_EXT = config["mediapipe"]["io"]["dfmxy_ext"]
+            DFMXY_EXT = config["main"]["param_ext"]
         except KeyError as e:
-            DFMXY_EXT = '.dfmxy'
+            DFMXY_EXT = '.txt' # default dfm extension is .txt
 
         # Check all the needed user-provided config values are here
         try:
@@ -513,7 +513,8 @@ class FaceWarp(Engine):
             np.savetxt(output_dfm_file,
                        dfmxy,
                        fmt="%d,%d,%d,%.8f,%.8f",
-                       header="mediapipe idx, posX, posY, defX, defY")
+                       header="idx, posX, posY, defX, defY", 
+                       comments="")
 
     @staticmethod
     def dfmxy_to_dfm(dfmxy_file, landmarks_file, output_dfm_file=None):

--- a/cleese_stim/engines/phase_vocoder/bpf.py
+++ b/cleese_stim/engines/phase_vocoder/bpf.py
@@ -43,6 +43,22 @@ def createBPF(tr, config, BPFtime, numPoints, endOnTrans, eqFreqVec=None):
 
     return BPF
 
+def create_BPF_header(tr, config): 
+    ''' 
+        returns a str that's the header for the file destined to store BPF values
+    '''
+
+    # for pitch, stretch and gain, BPF file is two-columned in the form time,value
+    if tr in ["pitch", "stretch", "gain"]:
+        header = "time,%s"%tr
+    # for eq, BPF file is in the form: time numBands freq1 ampl1 freq2 ampl2 ...
+    elif tr == "eq":
+        num_bands = config["eq"]["band"]["count"] + 1 # one more cutoff frequency than bands
+        header = "time,n_channels"
+        for band in range(0, num_bands):
+            header += ",freq_%d,ampl_%d"%(band,band)
+    return header
+
 
 def createBPFtimeVec(duration, local_pars, timeVec=None):
 

--- a/cleese_stim/engines/phase_vocoder/phase_vocoder.py
+++ b/cleese_stim/engines/phase_vocoder/phase_vocoder.py
@@ -18,7 +18,8 @@ import shutil
 from .bpf import (
         createBPFtimeVec,
         createBPFfreqs,
-        createBPF,)
+        createBPF,
+        create_BPF_header)
 from .audio_engine import (
         stft,
         istft,
@@ -153,7 +154,9 @@ class PhaseVocoder(Engine):
                     currBPFfile = os.path.join(
                             config["main"]['currOutPath'],
                             inFileNoExt+'.'+currFileNo+'.'+currTrString+BPF_EXT)
-                    np.savetxt(currBPFfile, BPF, '%.8f')
+                    BPF_header = create_BPF_header(tr, config)
+
+                    np.savetxt(currBPFfile, BPF, '%.8f', delimiter = ',', header = BPF_header, comments='')
 
                     if t == 0:
                         currOutFile.append(os.path.join(

--- a/cleese_stim/engines/phase_vocoder/phase_vocoder.py
+++ b/cleese_stim/engines/phase_vocoder/phase_vocoder.py
@@ -50,6 +50,12 @@ class PhaseVocoder(Engine):
         if BPF is None:
             doCreateBPF = True
 
+        try:
+            BPF_EXT = config["main"]["param_ext"]
+        except KeyError as e:
+            BPF_EXT = '.txt' # default bpf extension
+  
+
         if not sample_rate:
             log("ERROR: missing sample rate")
             return
@@ -146,7 +152,7 @@ class PhaseVocoder(Engine):
                 if file_output:
                     currBPFfile = os.path.join(
                             config["main"]['currOutPath'],
-                            inFileNoExt+'.'+currFileNo+'.'+currTrString+'_BPF.txt')
+                            inFileNoExt+'.'+currFileNo+'.'+currTrString+BPF_EXT)
                     np.savetxt(currBPFfile, BPF, '%.8f')
 
                     if t == 0:

--- a/docs/docs/api/general.md
+++ b/docs/docs/api/general.md
@@ -16,9 +16,14 @@ numFiles = 10
 
 # generate experiment folder with name based on current time
 generateExpFolder = true
+
+# parameter file extension (default: '.txt')
+param_ext = '.txt'
 ```
 
 Enabling the `generateExpFolder` option will generate a new folder inside `outPath` for each subsequent experiment. Whereas if this option
 is disabled, all experiment results are written directly in `outPath`.
+
+CLEESE engines store parameter files alongside each stimulus. By default, the name of these files are the same as the corresponding stimulus, with the `.txt` extention (ex. for `PhaseVocoder`, `file001.wav` and the corresponding `file001.txt`). This extension (and end of the file name) can be changed with the `param_ext` option (ex. `param_ext = '_bpf.txt` will store parameter files as e.g. `file001_bpf.txt`). 
 
 

--- a/docs/docs/tutorials/configs/random_pitch_profile.toml
+++ b/docs/docs/tutorials/configs/random_pitch_profile.toml
@@ -16,7 +16,7 @@ transf = ["pitch"]
 generateExpFolder = true
 
 # bpf file extension (default: '.txt')
-bpf_ext = '.txt'
+param_ext = '.txt'
 
 [analysis]
 

--- a/docs/docs/tutorials/configs/random_pitch_profile.toml
+++ b/docs/docs/tutorials/configs/random_pitch_profile.toml
@@ -15,6 +15,9 @@ transf = ["pitch"]
 # generate experiment folder with name based on current time
 generateExpFolder = true
 
+# bpf file extension (default: '.txt')
+bpf_ext = '.txt'
+
 [analysis]
 
 # analysis window length in seconds

--- a/docs/docs/tutorials/configs/random_speed_profile.toml
+++ b/docs/docs/tutorials/configs/random_speed_profile.toml
@@ -16,7 +16,7 @@ transf = ["stretch"]
 generateExpFolder = true
 
 # bpf file extension (default: '.txt')
-bpf_ext = '.txt'
+param_ext = '.txt'
 
 
 [analysis]

--- a/docs/docs/tutorials/configs/random_speed_profile.toml
+++ b/docs/docs/tutorials/configs/random_speed_profile.toml
@@ -15,6 +15,9 @@ transf = ["stretch"]
 # generate experiment folder with name based on current time
 generateExpFolder = true
 
+# bpf file extension (default: '.txt')
+bpf_ext = '.txt'
+
 
 [analysis]
 


### PR DESCRIPTION
## What

This PR changes the format of the BPF files that are stored by PhaseVocoder and FaceWarp to make them directly compatible with deployment in the JONES/revcor app (issue #18)

## Why

The revcor online experimentation app expects:
* that parameters are stored in filenames with the same basename as the stimuli and the .txt extension 
* file format with a header (which is used to get column names in the dataframe storing experiment's results) and 
* comma-separated. 
`PhaseVocoder`'s fixed behaviour so far has files as "_bpf.txt", no header, and tab separated. `FaceWarp` has header and comma-separated, and the ability to change file ext, but default is ".dfm"

## How

* added a `create_BPF_header` function in `bpf.py` that assembles header str depending on transform and config
* modified BPF save to include header and comma-separated
* added a param_ext option in config file syntax, which is now read by `PhaseVocoder` and replaces the old `dfm_ext` option in `FaceWarp`
* changed default `FaceWarp` ext to .txt
* set default `PhaseVocoder` ext to .txt
* added documentation on param_ext
* added param_ext to the tutorial config files

## Testing

Tested using the speech and face tutorial, checking correct file format and names in single calls & chained